### PR TITLE
Update torch-rb to fix Ruby >= 2.7 dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # windows-latest
-        ruby: ['2.7']
+        ruby: ['2.6']
         # '2.5', '2.4'
         experimental: [false]
-        # include:
-        #   - ruby: '2.7'
-        #     os: ubuntu-latest
-        #     experimental: true
-        #   - ruby: '2.7'
-        #     os: macos-latest
-        #     experimental: true
+        include:
+          - ruby: '2.7'
+            os: ubuntu-latest
+            experimental: true
+          - ruby: '2.7'
+            os: macos-latest
+            experimental: true
           # - ruby: '2.7'
           #   os: windows-latest
           #   experimental: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
     thor (1.0.1)
-    torch-rb (0.4.0)
+    torch-rb (0.4.1)
       rice (>= 2.2)
 
 PLATFORMS

--- a/README.adoc
+++ b/README.adoc
@@ -31,8 +31,6 @@ Secryst is composed of two separate gems:
 
 === General (and Secryst)
 
-* Ruby 2.7 (*MUST* - 2.6 does not work with the latest torch-rb)
-
 * `libtorch` (1.6.0)
 * `fftw`
 * `gsl`

--- a/secryst-trainer.gemspec
+++ b/secryst-trainer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.executables   << "secryst-trainer"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "torch-rb", '~> 0.4'
   spec.add_dependency "numo", '~> 0.1'

--- a/secryst.gemspec
+++ b/secryst.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   << "secryst"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "torch-rb", '~> 0.4'
   spec.add_dependency "thor", "~> 1.0"


### PR DESCRIPTION
New `torch-rb` version 0.4.1 has the bug fixed that did not let it run on Ruby 2.6.0.