### PR TITLE
crystal names: TypeScript package is npm 'secryst'

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ script to reveal its hidden reading — the vowels, phonemes, and word
 boundaries that live in the reader's mind but not on the page. This gem
 is the Ruby crystal of the family (Python: `pip install secryst` at
 https://github.com/secryst/secryst-py[secryst/secryst-py]; TypeScript:
-`@secryst/ml`). All crystals implement the *interscript-ml* contract —
+`npm i secryst`). All crystals implement the *interscript-ml* contract —
 the `models.yaml` index, IMF v1 model zips, and shared golden sets
 (https://github.com/interscript/interscript-ml[interscript/interscript-ml]) — and
 are diffed against each other in CI. Overrides: `SECRYST_INDEX`,

--- a/lib/secryst/imf.rb
+++ b/lib/secryst/imf.rb
@@ -6,7 +6,7 @@ require "open-uri"
 
 module Secryst
   # Interscript Model Format v1 — the byte-level runtime contract shared
-  # with the Python (interscript-ml) and TypeScript (@interscript/ml)
+  # with the Python (interscript-ml) and TypeScript (npm: secryst)
   # runtimes. Token ids follow the canonical ByT5 table: byte b -> b+3,
   # trailing EOS; pad=0, unk=2. Ids are NOT raw byte values.
   module IMF


### PR DESCRIPTION
## What

Name fix follow-through: the TypeScript crystal publishes as bare
`secryst` on npm (cross-registry symmetry with `pip install secryst` /
`gem 'secryst'`; the name was verified free). This drops the scoped
references from the README and the IMF module comment (which still said
`@interscript/ml`).

No code behavior changes; comment + docs only.

## Publish status

Awaiting `npm login` locally; tarball is built at
secryst-ts `secryst-0.1.0.tgz` (package.json name: `secryst`).
