### PR TITLE
release prep 1.0.0: gemspec identity + trusted-publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: release
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  rubygems:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - run: gem build secryst.gemspec
+      - uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 1.0.0
+
+- IMF v1 model-zip loading with member sha256 verification
+- models.yaml index resolution (`SECRYST_INDEX` / `SECRYST_CACHE`)
+- Byte-level ByT5 ONNX inference (plain + KV-cache decoder)
+- Cross-crystal golden parity CI vs the Python reference
+- Parts support for artifacts over the GitHub 2 GiB asset cap
+- Training moved out of the gem (lives in interscript-ml-train / secryst training playground)

--- a/secryst.gemspec
+++ b/secryst.gemspec
@@ -6,12 +6,17 @@ require 'secryst/version'
 Gem::Specification.new do |spec|
   spec.name          = "secryst"
   spec.version       = Secryst::VERSION
-  spec.summary       = "Seq2seq transformer for script conversion in Ruby."
-  spec.description   = %q{Seq2seq transformer for script conversion in Ruby.}
-  spec.homepage      = "https://github.com/secryst/secryst"
+  spec.summary       = "Ruby crystal: local ONNX vocalization/G2P implementing the interscript-ml contract."
+  spec.description   = %q{Secryst (scrying + crystal) reveals the hidden reading of a script — diacritization, vocalization, grapheme-to-phoneme — via local, sha256-verified IMF v1 ONNX models. Implements the interscript-ml contract (models.yaml index, byte tokenizer, golden parity). Sibling crystals: pip install secryst, npm i secryst.}
+  spec.homepage      = "https://www.secryst.org"
+  spec.metadata      = {
+    "homepage_uri" => "https://www.secryst.org",
+    "source_code_uri" => "https://github.com/secryst/secryst",
+    "changelog_uri" => "https://github.com/secryst/secryst/blob/master/README.adoc",
+  }
   spec.license       = "BSD-2-Clause"
 
-  spec.authors       = ['project_contibutors']
+  spec.authors       = ['Interscript / Secryst contributors']
 
   spec.files         = Dir.glob("{lib,exe,spec,maps}/**/*", File::FNM_DOTMATCH)
   spec.files         += ['README.adoc']


### PR DESCRIPTION
## What

Release preparation for secryst 1.0.0 (VERSION already 1.0.0 on master):

- gemspec: summary/description match the crystal identity; homepage
  points at secryst.org; authors field no longer a placeholder;
  metadata URIs for homepage/source/changelog.
- .github/workflows/release.yml: RubyGems trusted publishing via
  rubygems/release-gem (workflow_dispatch or GitHub Release).
- CHANGELOG.md for 1.0.0.

Does not cut the release itself — after merge, register a pending
publisher on rubygems.org for secryst/secryst (workflow release.yml),
then either `gh release create v1.0.0` or `gh workflow run release.yml`.
