### PR TITLE
fix: release task no longer does git operations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,11 +12,8 @@ task :build do
   FileUtils.mv(Dir['*.gem'], 'pkg')
 end
 
-desc 'Tags version, pushes to remote, and pushes gem'
+desc 'Pushes gem to RubyGems (tag is managed by GitHub Releases)'
 task :release => :build do
-  sh 'git', 'tag', "v#{Secryst::VERSION}"
-  sh "git push origin master"
-  sh "git push origin v#{Secryst::VERSION}"
   sh "ls pkg/*.gem | xargs -n 1 gem push"
 end
 


### PR DESCRIPTION
The rubygems/release-gem action runs rake release, which tried to git tag + git push — failing because v1.0.0 already exists (created via gh release create). The task now only builds and pushes the gem; tagging is owned by GitHub Releases.