### PR TITLE
docs: purge pre-restructure repo names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@
 - Byte-level ByT5 ONNX inference (plain + KV-cache decoder)
 - Cross-crystal golden parity CI vs the Python reference
 - Parts support for artifacts over the GitHub 2 GiB asset cap
-- Training moved out of the gem (lives in interscript-ml-train / secryst training playground)
+- Training moved out of the gem (lives in secryst-train)

--- a/TODO.modernize/04-phase3-secryst-thai-ipa.md
+++ b/TODO.modernize/04-phase3-secryst-thai-ipa.md
@@ -62,7 +62,7 @@ secryst/
 ### 3.6 Release
 - Cut `secryst_thai_ipa-v0.1.0` tag.
 - Upload ONNX + vocab to GitHub Release.
-- Update `ml-models/npm/models/manifest.json`: version `0.1.0`, status `research`.
+- Update `interscript-ml/npm/models/manifest.json`: version `0.1.0`, status `research`.
 
 ## Acceptance
 - [ ] CER ≤ 15% on Wiktionary test split

--- a/TODO.modernize/05-phase4-secryst-wiring.md
+++ b/TODO.modernize/05-phase4-secryst-wiring.md
@@ -114,7 +114,7 @@ change needed; secryst is just another `funcall-name` registered at
 runtime.
 
 ### 4.7 End-to-end test
-Add a test vector to `ml-models/tests/test_secryst_thai_ipa.py`:
+Add a test vector to `interscript-ml/tests/test_secryst_thai_ipa.py`:
 ```python
 @pytest.mark.parametrize("thai,expected_ipa", [
     ("ภาษาไทย", "pʰaːsaːtʰaj"),


### PR DESCRIPTION
## Summary
- purge pre-restructure names (ml-models -> interscript-ml, interscript-ml-train -> secryst-train) from docs/changelog pointers
- completes the rebrand definition of done from rababa/docs/CLIENT-AGENT-REBRAND-PROMPT.md

## Test plan
- [ ] docs-only change; CI green
