### PR TITLE
fix: pin model index to GitHub Releases + verify sha256 sidecar

### DIFF
--- a/lib/secryst/imf.rb
+++ b/lib/secryst/imf.rb
@@ -15,7 +15,7 @@ module Secryst
     EOS_ID = 1
     UNK_ID = 2
 
-    DEFAULT_INDEX_URL = "https://raw.githubusercontent.com/interscript/interscript-ml/main/models.yaml"
+    DEFAULT_INDEX_URL = "https://github.com/interscript/interscript-ml/releases/download/index-v1/models-index.yaml"
 
     class FormatError < StandardError; end
     class RegistryError < StandardError; end
@@ -142,13 +142,35 @@ module Secryst
 
       def load_index(source)
         text = if source.start_with?("http://", "https://")
-          URI.open(source) { |remote| remote.read }
+          fetch_index_with_sidecar(source)
         else
           File.read(source)
         end
         raw = YAML.safe_load(text, permitted_classes: [], aliases: false)
         raise RegistryError, "index must have version: 1" if raw["version"] != 1
         raw.fetch("models", {})
+      end
+      public :load_index
+
+      # HTTP sources must ship a sibling .sha256 sidecar; verify the
+      # body against it before parsing (GitHub Releases index assets do).
+      def fetch_index_with_sidecar(source)
+        body = URI.open(source, "rb") { |remote| remote.read }
+        sidecar =
+          begin
+            URI.open("#{source}.sha256") { |remote| remote.read }
+          rescue OpenURI::HTTPError => e
+            raise RegistryError, "index sha256 sidecar missing: #{source}.sha256 (#{e.message})"
+          end
+        expected = sidecar.to_s.strip.split(/\s+/).first.to_s
+        unless expected.match?(/\A[0-9a-fA-F]{64}\z/)
+          raise RegistryError, "index sha256 sidecar malformed: #{source}.sha256"
+        end
+        actual = Digest::SHA256.hexdigest(body)
+        unless actual == expected.downcase
+          raise RegistryError, "index sha256 mismatch: got #{actual}, sidecar says #{expected.downcase}"
+        end
+        body.force_encoding(Encoding::UTF_8)
       end
     end
   end

--- a/lib/secryst/version.rb
+++ b/lib/secryst/version.rb
@@ -1,3 +1,3 @@
 module Secryst
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/secryst/imf_spec.rb
+++ b/spec/secryst/imf_spec.rb
@@ -178,3 +178,59 @@ RSpec.describe Secryst::IMF do
     end
   end
 end
+
+  describe "index distribution contract" do
+    it "pins DEFAULT_INDEX_URL to a GitHub Release asset, never raw" do
+      expect(Secryst::IMF::DEFAULT_INDEX_URL).to match(
+        %r{\Ahttps://github\.com/interscript/interscript-ml/releases/download/index-v\d+/models-index\.yaml\z}
+      )
+      expect(Secryst::IMF::DEFAULT_INDEX_URL).not_to include("raw.githubusercontent")
+    end
+
+    it "verifies the .sha256 sidecar on HTTP index fetches" do
+      require "webrick"
+      body = "version: 1\nmodels: {}\n"
+      good = Digest::SHA256.hexdigest(body)
+      bad = "0" * 64
+
+      with_index_server = lambda do |sidecar, &blk|
+        server = WEBrick::HTTPServer.new(Port: 0, AccessLog: [], Logger: WEBrick::Log.new(File::NULL))
+        server.mount_proc "/models-index.yaml" do |_req, res|
+          res["Content-Type"] = "text/yaml"
+          res.body = body
+        end
+        server.mount_proc "/models-index.yaml.sha256" do |_req, res|
+          if sidecar.nil?
+            res.status = 404
+            res.body = "missing"
+          else
+            res["Content-Type"] = "text/plain"
+            res.body = "#{sidecar}  models-index.yaml\n"
+          end
+        end
+        port = server[:Port]
+        server_thread = Thread.new { server.start }
+        begin
+          blk.call("http://127.0.0.1:#{port}/models-index.yaml")
+        ensure
+          server.shutdown
+          server_thread.join(5)
+        end
+      end
+
+      with_index_server.call(good) do |url|
+        entries = Secryst::IMF.load_index(url)
+        expect(entries).to eq({})
+      end
+      with_index_server.call(bad) do |url|
+        expect {
+          Secryst::IMF.load_index(url)
+        }.to raise_error(Secryst::IMF::RegistryError, /index sha256 mismatch/)
+      end
+      with_index_server.call(nil) do |url|
+        expect {
+          Secryst::IMF.load_index(url)
+        }.to raise_error(Secryst::IMF::RegistryError, /index sha256/)
+      end
+    end
+  end

--- a/spec/secryst/imf_spec.rb
+++ b/spec/secryst/imf_spec.rb
@@ -188,46 +188,54 @@ end
     end
 
     it "verifies the .sha256 sidecar on HTTP index fetches" do
-      require "webrick"
+      require "socket"
       body = "version: 1\nmodels: {}\n"
       good = Digest::SHA256.hexdigest(body)
       bad = "0" * 64
 
-      with_index_server = lambda do |sidecar, &blk|
-        server = WEBrick::HTTPServer.new(Port: 0, AccessLog: [], Logger: WEBrick::Log.new(File::NULL))
-        server.mount_proc "/models-index.yaml" do |_req, res|
-          res["Content-Type"] = "text/yaml"
-          res.body = body
-        end
-        server.mount_proc "/models-index.yaml.sha256" do |_req, res|
-          if sidecar.nil?
-            res.status = 404
-            res.body = "missing"
-          else
-            res["Content-Type"] = "text/plain"
-            res.body = "#{sidecar}  models-index.yaml\n"
+      serve = lambda do |sidecar, &blk|
+        server = TCPServer.new("127.0.0.1", 0)
+        port = server.addr[1]
+        thread = Thread.new do
+          loop do
+            client = server.accept rescue break
+            request = client.readline
+            client.each_line { |line| break if line == "\r\n" }
+            path = request.split(" ")[1]
+            case path
+            when "/models-index.yaml"
+              client.write("HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}")
+            when "/models-index.yaml.sha256"
+              if sidecar.nil?
+                client.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+              else
+                payload = "#{sidecar}  models-index.yaml\n"
+                client.write("HTTP/1.1 200 OK\r\nContent-Length: #{payload.bytesize}\r\n\r\n#{payload}")
+              end
+            else
+              client.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+            end
+            client.close
           end
         end
-        port = server[:Port]
-        server_thread = Thread.new { server.start }
         begin
           blk.call("http://127.0.0.1:#{port}/models-index.yaml")
         ensure
-          server.shutdown
-          server_thread.join(5)
+          server.close
+          thread.join(5)
         end
       end
 
-      with_index_server.call(good) do |url|
+      serve.call(good) do |url|
         entries = Secryst::IMF.load_index(url)
         expect(entries).to eq({})
       end
-      with_index_server.call(bad) do |url|
+      serve.call(bad) do |url|
         expect {
           Secryst::IMF.load_index(url)
         }.to raise_error(Secryst::IMF::RegistryError, /index sha256 mismatch/)
       end
-      with_index_server.call(nil) do |url|
+      serve.call(nil) do |url|
         expect {
           Secryst::IMF.load_index(url)
         }.to raise_error(Secryst::IMF::RegistryError, /index sha256/)


### PR DESCRIPTION
raw.githubusercontent.com is never used for any data path — the model
index ships as a GitHub Release asset (interscript-ml index-v1), same
channel as maps IR artifacts and model weights.

- DEFAULT_INDEX_URL →
  https://github.com/interscript/interscript-ml/releases/download/index-v1/models-index.yaml
- fetch_index_with_sidecar(): pulls the sibling .sha256 and rejects on
  mismatch / missing / malformed, before parsing
- load_index is public class method now — the TS/Python crystals export
  loadIndex/load_index publicly; Ruby matches the contract
- Local file indexes unchanged
- Specs: pin shape + good/bad/missing sidecar via WEBrick
- Version 1.0.1

Sibling PRs: secryst-ts, secryst-py; interscript-ts#47 does the same
for the interscript runtime.
